### PR TITLE
부스 상세 CSS 오류 수정

### DIFF
--- a/src/components/BoothDetail/BoothComments.js
+++ b/src/components/BoothDetail/BoothComments.js
@@ -280,7 +280,7 @@ const Delete = styled.img`
 
 const CommentInputWrapper = styled.div`
   width: 100%;
-  height: 60px;
+  height: 70px;
   margin-top: 25px;
   position: fixed;
   bottom: 0;
@@ -292,7 +292,7 @@ const CommentInputWrapper = styled.div`
 
 const CommentInputContainer = styled.div`
   width: calc(100% - 40px);
-  height: 40px;
+  height: 35px;
   margin: 0 auto;
   background-color: var(--gray0);
   border-radius: 10px;
@@ -311,7 +311,7 @@ const CommentInput = styled.input`
     outline: none;
   }
 
-  font-family: "Pretendard-Regular";
+  font-family: "Pretendard";
   font-weight: 300;
   font-size: 14px;
 `;

--- a/src/components/BoothDetail/BoothInfo.js
+++ b/src/components/BoothDetail/BoothInfo.js
@@ -29,7 +29,7 @@ const BoothInfo = props => {
       return (
         <div style={{ position: "absolute", zIndex: "-100", width: "100%" }}>
           <InfoTextContainer>
-            <ShortInfo ref={ref => (this.span = ref)} style={{ color: "#000" }}>
+            <ShortInfo ref={ref => (this.span = ref)} style={{ color: "#fff" }}>
               {infoString &&
                 (infoString.includes("\n") ? (
                   <>
@@ -150,7 +150,7 @@ const InfoTextContainer = styled.div`
 `;
 
 const ShortInfo = styled.p`
-  font-family: "Pretendard-Regular";
+  font-family: "Pretendard";
   font-size: 14px;
   font-weight: 300;
   color: var(--black);
@@ -166,7 +166,7 @@ const ShortInfo = styled.p`
 `;
 
 const LongInfo = styled.p`
-  font-family: "Pretendard-Regular";
+  font-family: "Pretendard";
   font-size: 14px;
   font-weight: 300;
   color: var(--black);

--- a/src/components/BoothDetail/BoothNotice.js
+++ b/src/components/BoothDetail/BoothNotice.js
@@ -8,60 +8,145 @@ const BoothNotice = props => {
   return (
     <>
       <NoticeWrapper>
-        <NoticeContainer
-          onClick={() => props.handleNotice()}
-          style={{ height: props.notice ? "auto" : "35px" }}
-        >
-          <Notice src={noticeicon} />
-          <NoticeTextContainer>
-            <Pretendard size="14px" weight="500" color="var(--black)">
-              부스 공지사항
-            </Pretendard>
-            {props.notice ? (
-              <div style={{ margin: "10px 0 10px 0", wordBreak: "keep-all" }}>
+        {noticeString === "" ? (
+          <>
+            <NoticeContainer
+              onClick={() => props.handleNotice()}
+              style={{
+                height: "35px",
+              }}
+            >
+              <Notice src={noticeicon} />
+              <NoticeTextContainer>
                 <Pretendard
                   size="14px"
-                  weight="300"
+                  weight="500"
                   color="var(--black)"
-                  style={{ lineHeight: "17px" }}
+                  style={{ marginTop: "9px" }}
                 >
-                  {noticeString &&
-                    (noticeString.includes("\n") ? (
-                      <>
-                        {noticeString.split("\n").map(line => {
-                          return (
-                            <span>
-                              {line}
-                              <br />
-                            </span>
-                          );
-                        })}
-                      </>
-                    ) : (
-                      <>
-                        <span>{noticeString}</span>
-                      </>
-                    ))}
+                  부스 공지사항
                 </Pretendard>
-              </div>
-            ) : null}
-          </NoticeTextContainer>
-          {props.notice ? (
-            <Up
-              src={back}
+                {props.notice ? (
+                  <div
+                    style={{
+                      margin: noticeString === "" ? "0" : "10px 0 10px 0",
+                      wordBreak: "keep-all",
+                    }}
+                  >
+                    <Pretendard
+                      size="14px"
+                      weight="300"
+                      color="var(--black)"
+                      style={{ lineHeight: "17px" }}
+                    >
+                      {noticeString &&
+                        (noticeString.includes("\n") ? (
+                          <>
+                            {noticeString.split("\n").map(line => {
+                              return (
+                                <span>
+                                  {line}
+                                  <br />
+                                </span>
+                              );
+                            })}
+                          </>
+                        ) : (
+                          <>
+                            <span>{noticeString}</span>
+                          </>
+                        ))}
+                    </Pretendard>
+                  </div>
+                ) : null}
+              </NoticeTextContainer>
+              {props.notice ? (
+                <Up
+                  src={back}
+                  style={{
+                    margin: "11px 0 0 5px",
+                  }}
+                />
+              ) : (
+                <Down
+                  src={back}
+                  style={{
+                    margin: "11px 0 0 5px",
+                  }}
+                />
+              )}
+            </NoticeContainer>
+          </>
+        ) : (
+          <>
+            <NoticeContainer
+              onClick={() => props.handleNotice()}
               style={{
-                margin: "11px 0 0 5px",
+                height: props.notice ? "auto" : "35px",
               }}
-            />
-          ) : (
-            <Down
-              src={back}
-              style={{
-                margin: "11px 0 0 5px",
-              }}
-            />
-          )}
-        </NoticeContainer>
+            >
+              <Notice src={noticeicon} />
+              <NoticeTextContainer>
+                <Pretendard
+                  size="14px"
+                  weight="500"
+                  color="var(--black)"
+                  style={{ marginTop: "9px" }}
+                >
+                  부스 공지사항
+                </Pretendard>
+                {props.notice ? (
+                  <div
+                    style={{
+                      margin: noticeString === "" ? "0" : "10px 0 10px 0",
+                      wordBreak: "keep-all",
+                    }}
+                  >
+                    <Pretendard
+                      size="14px"
+                      weight="300"
+                      color="var(--black)"
+                      style={{ lineHeight: "17px" }}
+                    >
+                      {noticeString &&
+                        (noticeString.includes("\n") ? (
+                          <>
+                            {noticeString.split("\n").map(line => {
+                              return (
+                                <span>
+                                  {line}
+                                  <br />
+                                </span>
+                              );
+                            })}
+                          </>
+                        ) : (
+                          <>
+                            <span>{noticeString}</span>
+                          </>
+                        ))}
+                    </Pretendard>
+                  </div>
+                ) : null}
+              </NoticeTextContainer>
+              {props.notice ? (
+                <Up
+                  src={back}
+                  style={{
+                    margin: "11px 0 0 5px",
+                  }}
+                />
+              ) : (
+                <Down
+                  src={back}
+                  style={{
+                    margin: "11px 0 0 5px",
+                  }}
+                />
+              )}
+            </NoticeContainer>
+          </>
+        )}
       </NoticeWrapper>
     </>
   );
@@ -79,6 +164,7 @@ const NoticeWrapper = styled.div`
 
 const NoticeContainer = styled.div`
   width: calc(100% - 40px);
+  height: 35px;
   margin-top: 7.5px;
   display: flex;
 
@@ -93,7 +179,6 @@ const Notice = styled.img`
 `;
 
 const NoticeTextContainer = styled.div`
-  margin-top: 9px;
   width: calc(100% - 60px);
   height: auto;
 `;

--- a/src/pages/boothpage/BoothDetailPage.js
+++ b/src/pages/boothpage/BoothDetailPage.js
@@ -11,7 +11,6 @@ import BoothComments from "../../components/BoothDetail/BoothComments";
 import ImgModal from "../../components/BoothDetail/ImgModal";
 import { GetBooth, LikeBooth, UnLikeBooth } from "../../api/booth";
 
-import back from "../../images/navbar/back.svg";
 import greenheart from "../../images/greenheart.svg";
 import heart from "../../images/heart.svg";
 import booththumnail from "../../images/detail/booththumnail.svg";
@@ -112,9 +111,6 @@ const BoothDetailPage = () => {
             src={booth.thumnail === "" ? booththumnail : booth.thumnail}
           />
         </MainImage>
-        <BackBtn onClick={() => nav("/category")}>
-          <Back src={back} />
-        </BackBtn>
         <TitleWrapper>
           <PyeongChang_Peace size="22px" weight="700" color="var(--green3)">
             {booth.name}
@@ -177,7 +173,7 @@ const Wrapper = styled.div`
 
 const MainImage = styled.div`
   width: 100%;
-  height: 250px;
+  height: auto;
 `;
 
 const MainImg = styled.img`
@@ -185,29 +181,6 @@ const MainImg = styled.img`
   height: 100%;
   object-fit: cover;
   -webkit-user-drag: none;
-`;
-
-const Back = styled.img`
-  width: 10px;
-  height: 17px;
-  margin-right: 3px;
-`;
-
-const BackBtn = styled.div`
-  width: 30px;
-  height: 30px;
-  background-color: var(--white);
-  border-radius: 50%;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  position: absolute;
-  margin-top: 20px;
-  margin-left: 20px;
-
-  cursor: pointer;
 `;
 
 const TitleWrapper = styled.div`


### PR DESCRIPTION
# 📚 개요

부스 상세 페이지에서
1. 뒤로가기 버튼 제거
2. 대표 사진 비율 전부 유지
3. 댓글창 여백 늘림 -> 홈 바와 겹치는지 재확인 필요!
4. 부스 공지 없을때 height auto로 길이 약간 늘어남 해결
5. 제목 오버플로우 패딩 추가(이전 pr)

# ✨ 작업 페이지 / 기능 작동 시현

![localhost_3000_category_detail_2(iPhone 12 Pro)](https://user-images.githubusercontent.com/102040717/188680572-5423bdde-198b-4900-bee3-2ea4b915f5b8.png)

# 🌞 추가 코멘트

오늘 회의에서 나온 수정 사항 모두 반영하였습니다
스크롤 애니메이션에 도전해볼게요..
